### PR TITLE
fix: Reduce latency in restaurant recommendation API

### DIFF
--- a/restaurants/serializers.py
+++ b/restaurants/serializers.py
@@ -3,6 +3,10 @@ from .models import Restaurant, Review
 from users.serializers import SimpleUserSerializer
 from promotions.serializers import PromotionSerializer, CouponSerializer
 
+class FullRestaurantSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Restaurant
+        fields = '__all__'
 
 class ReviewSerializer(serializers.ModelSerializer):
     user = SimpleUserSerializer(read_only=True)

--- a/restaurants/views.py
+++ b/restaurants/views.py
@@ -2,7 +2,7 @@ from rest_framework.views import APIView
 from rest_framework.decorators import api_view, permission_classes
 from users.utils import token_required_fbv, token_required_cbv
 from .models import Review, Restaurant
-from .serializers import ReviewSerializer
+from .serializers import ReviewSerializer, FullRestaurantSerializer
 from users.models import User, Favorite
 from rest_framework.response import Response
 from rest_framework import status
@@ -13,6 +13,7 @@ from restaurants.models import Restaurant
 from utilities.cloudinary_upload import upload_to_cloudinary
 from utilities.place_api import get_google_photo
 from .serializers import RestaurantDetailSerializer
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 
 @api_view(['POST'])
@@ -22,42 +23,67 @@ def recommendRestaurants(request):
     mains = data['mains']
     staples = data['staples']
     latitude = data['user_location']['latitude']
-    longitude = data['user_location']['longitude']  
-
-
-    location = f'{latitude},{longitude}'
-    
+    longitude = data['user_location']['longitude']
+    location = f'{latitude},{longitude}'    
     keywords = openai_api(flavors, mains, staples)
 
-    cleaned_result = [] 
+    selected_restaurants = None 
 
     for keyword in keywords:
-        restaurants_data = text_search(keyword, location, 800, count=10)
-        if len(restaurants_data) >= 10: 
-            
+        restaurants = text_search(keyword, location, 800, count=10)
+        if len(restaurants) >= 10:
+            selected_restaurants = restaurants
+            break
+    
+    place_ids = [place['place_id'] for place in selected_restaurants]
+    existing_restaurants = Restaurant.objects.filter(place_id__in=place_ids).only("place_id", "image_url")
+    image_map = {restaurant.place_id: restaurant.image_url for restaurant in existing_restaurants if restaurant.image_url}
+    missing_image_ids = set(place_ids) - set(image_map.keys())
+    places_need_image = [place for place in selected_restaurants if place['place_id'] in missing_image_ids]
 
-            for place in restaurants_data:
-                if len(cleaned_result) >= 10:
-                    break  
+    def fetch_and_upload_image(place):
+        place_id = place['place_id']
+        photo_ref = place.get('google_photo_reference')
+        print('ref')
+        print(photo_ref)
+        if not photo_ref:
+            return (place_id, None)
 
-                upsert_restaurant(place)  
+        photo_bytes = get_google_photo(photo_ref)
+        print('photo')
+        print(photo_bytes)
+        if not photo_bytes:
+            return (place_id, None)
 
-                db_restaurant = Restaurant.objects.filter(place_id=place['place_id']).first()
-                image_url = db_restaurant.image_url if db_restaurant else None
+        try:
+            image_url = upload_to_cloudinary(photo_bytes, filename=place_id)
+            print('url')
+            print(image_url)
+            return (place_id, image_url)
+        except Exception:
+            return (place_id, None)
 
-                cleaned_result.append({
-                'name': place['name'],
-                'address': place['address'],
-                'google_rating': place.get('google_rating'),
-                'latitude': place['latitude'],
-                'longitude': place['longitude'],
-                'types': place['types'],
-                'user_ratings_total': place.get('user_ratings_total'),                
-                'place_id': place['place_id'],
-                'image_url': image_url,         
-                'uuid': str(db_restaurant.uuid) ,       
-            } )
-    return Response({'result': cleaned_result}, status=status.HTTP_200_OK)
+    print(image_map)
+
+    with ThreadPoolExecutor(max_workers=5) as executor:
+        futures = [executor.submit(fetch_and_upload_image, place) for place in places_need_image]
+        for future in as_completed(futures):
+            place_id, url = future.result()
+            if url:
+                image_map[place_id] = url
+    
+    restaurant_instances = []
+
+    for place in selected_restaurants:
+        place['image_url'] = image_map.get(place['place_id'])
+        restaurant, _ = Restaurant.objects.update_or_create(
+            place_id=place['place_id'],
+            defaults=place
+        )
+        restaurant_instances.append(restaurant)
+
+    serializer = FullRestaurantSerializer(restaurant_instances, many=True)
+    return Response({'result': serializer.data}, status=200)
 
 @api_view(['POST'])
 @token_required_fbv
@@ -83,69 +109,6 @@ class RestaurantDetailView(APIView):
             context={"request": request}
         )
         return Response({"result": serializer.data})
-
-def upsert_restaurant(place): 
-    place_id = place.get("place_id")
-    if not place_id:
-        return
-
-    photo_ref = place.get('google_photo_reference')
-    image_url = None    
-
-    restaurant = Restaurant.objects.filter(place_id=place_id).first()
-
-    if restaurant:
-        if not restaurant.image_url and photo_ref:
-            photo_bytes = get_google_photo(photo_ref)
-            if photo_bytes:
-                try:
-                    image_url = upload_to_cloudinary(photo_bytes, filename=place_id)
-                    restaurant.image_url = image_url
-                    restaurant.save()
-                except Exception as e:
-                    pass
-        
-        updated = False
-        if restaurant.google_rating != place.get('google_rating'):
-            restaurant.google_rating = place.get('google_rating')
-            updated = True
-        if restaurant.address != place.get('address'):
-            restaurant.address = place.get('address')
-            updated = True
-        if restaurant.name != place.get('name'):
-            restaurant.name = place.get('name')
-            updated = True
-        if restaurant.user_ratings_total != place.get('user_ratings_total'):
-            restaurant.user_ratings_total = place.get('user_ratings_total')
-            updated = True
-        if restaurant.types != ', '.join(place.get('types', [])):
-            restaurant.types = ', '.join(place.get('types', []))
-            updated = True
-        if updated:
-            restaurant.save()
-
-    else:
-        if photo_ref:
-            photo_bytes = get_google_photo(photo_ref)
-            if photo_bytes:
-                try:
-                    image_url = upload_to_cloudinary(photo_bytes, filename=place_id)
-                except Exception as e:
-                    pass
-
-        
-        Restaurant.objects.create(
-            place_id=place_id,
-            name=place.get('name'),
-            address=place.get('address'),
-            google_rating=place.get('google_rating'),
-            latitude=place.get('latitude'),
-            longitude=place.get('longitude'),
-            types=', '.join(place.get('types', [])),
-            user_ratings_total=place.get('user_ratings_total'),
-            google_photo_reference=photo_ref,
-            image_url=image_url
-        )
 
 class FavoriteRestaurantView(APIView):
     @token_required_cbv

--- a/restaurants/views.py
+++ b/restaurants/views.py
@@ -44,26 +44,18 @@ def recommendRestaurants(request):
     def fetch_and_upload_image(place):
         place_id = place['place_id']
         photo_ref = place.get('google_photo_reference')
-        print('ref')
-        print(photo_ref)
         if not photo_ref:
             return (place_id, None)
 
         photo_bytes = get_google_photo(photo_ref)
-        print('photo')
-        print(photo_bytes)
         if not photo_bytes:
             return (place_id, None)
 
         try:
             image_url = upload_to_cloudinary(photo_bytes, filename=place_id)
-            print('url')
-            print(image_url)
             return (place_id, image_url)
         except Exception:
             return (place_id, None)
-
-    print(image_map)
 
     with ThreadPoolExecutor(max_workers=5) as executor:
         futures = [executor.submit(fetch_and_upload_image, place) for place in places_need_image]

--- a/utilities/place_api.py
+++ b/utilities/place_api.py
@@ -51,7 +51,7 @@ def text_search(keyword, location, radius, count=61):
 
 def get_google_photo(photo_reference, max_width = 400):
     url = (
-        f'{GOOGLE_MAP_API_BASE_URL}/place/photo'
+        f'{GOOGLE_MAP_API_BASE_URL}/photo'
         f'?maxwidth={max_width}&photo_reference={photo_reference}&key={API_KEY}'
     )
 


### PR DESCRIPTION
大改了restaurant detail的view
使用了ThreadPoolExecutor一次能讓要抓十次圖片的行為不必等前一個抓下來上傳完才進行
並且重寫了運作邏輯 因為API增加了UUID的需求
所以邏輯變成:
    前端post>後端接資料>openai>place api text search>從資料庫檢查這十筆餐廳有沒有已存在的圖片>抓圖補圖>存入資料庫>回傳值打成API