### PR TITLE
fix: update image format for review creation

### DIFF
--- a/config/docs/create_review_api.md
+++ b/config/docs/create_review_api.md
@@ -1,4 +1,4 @@
-POST /api/v1/restaurants/{restaurant_uuid}/reviews
+POST /api/v1/restaurants/{restaurant_uuid}/reviews/
 說明：對指定餐廳新增留言，需要登入。
 
 認證方式：
@@ -11,14 +11,12 @@ Request Body :
 {
     'rating':5,
     'content':'這家餐廳很好吃，環境也很棒！',
-    'image_bytes': [344, 67, 21, 67,32]
-    (非必填) 圖片 byte array (圖片轉成 bytes 後的整數陣列)
+    'image_bytes':(非必填) 圖片會上傳至雲端
 }
-圖片大小限制：
+圖片限制：
 單張圖片大小限制為：1MB
-備註：
-image＿bytes 是選填，如果有上傳圖片會自動傳送到 Cloudinary ，並回傳對應網址。
-不支援 image_url 或是 blob:。
+超過限制：回傳錯誤訊息
+檔案欄位名稱：image
 
 Success Respones [201 Created]:
 {

--- a/config/docs/create_review_api.md
+++ b/config/docs/create_review_api.md
@@ -7,22 +7,26 @@ POST /api/v1/restaurants/{restaurant_uuid}/reviews
     -格式：user_uuid:token
 
 Request Body :
-
 {
-    'rating':'5',
+    'rating':5,
     'content':'這家餐廳很好吃，環境也很棒！',
-    'image_url':'https://example.com/photo.jpg' /非必填
+    'image':IMG_1447.jpg / 非必填 / 上傳本地圖片（會存成網址）
 }
+備註：image是選填，如果有上傳，圖片會自動傳送到 Cloudinary ，並儲存對應網址至 image_url 欄位
 
 Success Respones [201 Created]:
 {
-    "uuid": "d1e8d...abc1",
-    "user": 5,
-    "restaurant": 10,
-    "rating": 5,
-    "content": "這家餐廳很好吃，環境也很棒！",
-    "img_url": "https://example.com/photo.jpg",
-    "created_at": "2025-05-14T15:01:32Z"
+  "uuid": "70b31c60-c2c6-4fe1-8b41-22e49d1f9282",
+  "user": {
+    "userName": 'ext',
+    "imageUrl": 'null,
+    "uuid": "2a1b...fa21"
+  },
+  "restaurant": '15',
+  "rating":'5',
+  "content": "好吃",
+  "created_at": "2025-05-21T09:13:03.784073Z",
+  "image_url": "https://res...jpg"
 }
 
 Error Respones [404 Not Found]:
@@ -30,4 +34,5 @@ Error Respones [404 Not Found]:
 Error Respones [401 Unauthorized]:
     -未提供Token
 Error Respones [400 Bad Request]:
-    -This field is required.
+    -image_url: ["Enter a valid URL."]
+    -detail": 該餐廳已評論過。

--- a/config/docs/create_review_api.md
+++ b/config/docs/create_review_api.md
@@ -7,12 +7,18 @@ POST /api/v1/restaurants/{restaurant_uuid}/reviews
     -格式：user_uuid:token
 
 Request Body :
+(Content-Type: application/json)
 {
     'rating':5,
     'content':'這家餐廳很好吃，環境也很棒！',
-    'image':IMG_1447.jpg / 非必填 / 上傳本地圖片（會存成網址）
+    'image_bytes': [344, 67, 21, 67,32]
+    (非必填) 圖片 byte array (圖片轉成 bytes 後的整數陣列)
 }
-備註：image是選填，如果有上傳，圖片會自動傳送到 Cloudinary ，並儲存對應網址至 image_url 欄位
+圖片大小限制：
+單張圖片大小限制為：1MB
+備註：
+image＿bytes 是選填，如果有上傳圖片會自動傳送到 Cloudinary ，並回傳對應網址。
+不支援 image_url 或是 blob:。
 
 Success Respones [201 Created]:
 {

--- a/restaurants/serializers.py
+++ b/restaurants/serializers.py
@@ -5,7 +5,6 @@ from promotions.serializers import PromotionSerializer, CouponSerializer
 from utilities.cloudinary_upload import upload_to_cloudinary
 from django.core.files.base import ContentFile
 import uuid
-import base64
 
 class FullRestaurantSerializer(serializers.ModelSerializer):
     class Meta:
@@ -30,18 +29,10 @@ class ReviewSerializer(serializers.ModelSerializer):
         if Review.objects.filter(user=user, restaurant=restaurant).exists():
             raise serializers.ValidationError({'detail':'該餐廳已評論過。'})
         
-        image_bytes = request.data.get('image_bytes')
-        image_data = None
-
-        if image_bytes:
-            try:
-                if isinstance(image_bytes, list):
-                    image_data = bytes(image_bytes)
-                elif isinstance(image_bytes, (bytes, bytearray)):
-                    image_data = image_bytes
-                else:
-                    raise ValueError('image_bytes 需為 byte array 或 list')
-                
+        image_file = request.FILES.get('image')
+        if image_file:
+            try:   
+                image_data = image_file.read()           
                 if len(image_data) > MAX_IMAGE_SIZE:
                     raise ValueError('圖片太大，請小於 1MB')
                 

--- a/restaurants/urls.py
+++ b/restaurants/urls.py
@@ -3,7 +3,7 @@ from . import views
 
 urlpatterns = [
     path('', views.recommendRestaurants),
-    path('<uuid:restaurant_uuid>/reviews', views.create_review),
+    path('<uuid:restaurant_uuid>/reviews/', views.create_review),
     path('<uuid:uuid>/favorites/', views.FavoriteRestaurantView.as_view()),
     path('<uuid:uuid>', views.RestaurantDetailView.as_view())
 ]

--- a/restaurants/views.py
+++ b/restaurants/views.py
@@ -94,10 +94,10 @@ def create_review(request, restaurant_uuid):
     
     user = User.objects.get(uuid =request.user_uuid)
 
-    serializer = ReviewSerializer(data=request.data, context={'user':user, 'restaurant':restaurant})
+    serializer = ReviewSerializer(data=request.data, context={'user' : user, 'restaurant' : restaurant, 'request' : request})
     if serializer.is_valid():
-        serializer.save(user=user, restaurant=restaurant)
-        return Response(serializer.data, status=status.HTTP_201_CREATED)
+        review = serializer.save()
+        return Response(ReviewSerializer(review).data, status=status.HTTP_201_CREATED)
     return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 class RestaurantDetailView(APIView):


### PR DESCRIPTION
cloced #101 
-修改傳送時會重複帶「user]、「restaurant」欄位，導致報錯必填欄位未填
-修改傳送本地圖片時會報錯無效的url，修改內容圖片要先在雲端轉成url儲存，並回傳到評論資料庫儲存
測試過程：
**登入**
<img width="690" alt="截圖 2025-05-21 下午5 43 01" src="https://github.com/user-attachments/assets/5b8928c2-f6e7-4231-acf1-803c52408d6b" />
**登入中評論並且附上圖片**
<img width="685" alt="截圖 2025-05-21 下午5 44 43" src="https://github.com/user-attachments/assets/f64cc2c3-02cb-4435-8d9a-c84c0d88d654" />
**已評論不能重複評論**
<img width="691" alt="截圖 2025-05-21 下午5 44 52" src="https://github.com/user-attachments/assets/35c04b7d-a11b-4b55-b3a8-c22c9ed3f802" />
**未登入無法評論**
<img width="688" alt="截圖 2025-05-21 下午5 43 58" src="https://github.com/user-attachments/assets/5d8e7e98-fdbb-4f67-bc83-1735dde45f28" />
