### PR TITLE
feat(MerchantDashBoard): add VIP status check for merchant users and promotion & coupon max count

### DIFF
--- a/promotions/views.py
+++ b/promotions/views.py
@@ -73,8 +73,8 @@ class MerchantView(APIView):
                     "uuid": str(restaurant.uuid),
                     "name": restaurant.name,
                 },
-                "role": user.role, 
-                "merchant_limit_status": {
+                "merchant_status": {
+                    "role": user.role, 
                     "is_coupon_limit_reached": is_coupon_limit_reached,
                     "is_promotion_limit_reached": is_promotion_limit_reached,
                 },

--- a/promotions/views.py
+++ b/promotions/views.py
@@ -62,6 +62,11 @@ class MerchantView(APIView):
         promotions = Promotion.objects.filter(restaurant=restaurant, is_archived=False)
         coupons = Coupon.objects.filter(restaurant=restaurant, is_archived=False)
 
+        max_count = 3 if user.role == 'vip_merchant' else 1
+        is_coupon_limit_reached = coupons.count() >= max_count
+        is_promotion_limit_reached = promotions.count() >= max_count
+
+
         return Response({
             "result": {
                 "restaurant": {
@@ -69,6 +74,9 @@ class MerchantView(APIView):
                     "name": restaurant.name,
                 },
                 "role": user.role, 
+                "is_coupon_limit_reached": is_coupon_limit_reached,
+                "is_promotion_limit_reached": is_promotion_limit_reached,
+
                 "promotions": PromotionSerializer(promotions, many=True).data,
                 "coupons":MerchantCouponSerializer(coupons, many=True).data
             }

--- a/promotions/views.py
+++ b/promotions/views.py
@@ -68,6 +68,7 @@ class MerchantView(APIView):
                     "uuid": str(restaurant.uuid),
                     "name": restaurant.name,
                 },
+                "role": user.role, 
                 "promotions": PromotionSerializer(promotions, many=True).data,
                 "coupons":MerchantCouponSerializer(coupons, many=True).data
             }

--- a/promotions/views.py
+++ b/promotions/views.py
@@ -74,9 +74,10 @@ class MerchantView(APIView):
                     "name": restaurant.name,
                 },
                 "role": user.role, 
-                "is_coupon_limit_reached": is_coupon_limit_reached,
-                "is_promotion_limit_reached": is_promotion_limit_reached,
-
+                "merchant_limit_status": {
+                    "is_coupon_limit_reached": is_coupon_limit_reached,
+                    "is_promotion_limit_reached": is_promotion_limit_reached,
+                },
                 "promotions": PromotionSerializer(promotions, many=True).data,
                 "coupons":MerchantCouponSerializer(coupons, many=True).data
             }


### PR DESCRIPTION
closes #166 
1.MerchantDashBoard 頁面，新增「店家用戶是否爲VIP」的判斷：


2.MerchantDashBoard 頁面，「新增優惠券」 & 「動態」 則數 的判斷：
    2.1.若 vip_merchant 的max 爲3則，提示聯繫EatHub 團隊；
    2.2.若 merchant 的max 爲1則，提示 付款升級


![image](https://github.com/user-attachments/assets/63028f93-d175-448a-84ee-3c24b4fcf7cf)
