### PR TITLE
fix: use default location when user location is missing or invalid

### DIFF
--- a/restaurants/views.py
+++ b/restaurants/views.py
@@ -22,8 +22,8 @@ class RecommendRestaurants(APIView):
         flavors = data['flavors']
         mains = data['mains']
         staples = data['staples']
-        latitude = data['user_location']['latitude']
-        longitude = data['user_location']['longitude']
+        latitude = data['user_location']['latitude'] or 25.042458653940916
+        longitude = data['user_location']['longitude'] or 121.51376697006941
         location = f'{latitude},{longitude}'
         keywords = openai_api(find_dish(flavors, mains, staples)).split(',')
         random.shuffle(keywords)


### PR DESCRIPTION
當使用者沒提供定位的時候將使用者定位在五倍

close #233 